### PR TITLE
install_pkg.bat 파일 정리

### DIFF
--- a/install_lib_ubuntu.sh
+++ b/install_lib_ubuntu.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-DEBIAN_FRONTEND=noninteractive sudo apt-get update -y -q
-DEBIAN_FRONTEND=noninteractive sudo apt-get upgrade -y -q
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -q \
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -y -q
+sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -q
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q \
      apparmor \
      apt-file \
      autoconf \
@@ -72,7 +72,9 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -q \
      uuid-dev \
      vim \
      wget \
-     zip unzip bzip2 \
+     zip \
+     unzip \
+     bzip2 \
     && echo
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y -q autoremove
-DEBIAN_FRONTEND=noninteractive sudo apt-get -y -q clean
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -q autoremove
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -q clean

--- a/install_pkg.bat
+++ b/install_pkg.bat
@@ -10,27 +10,74 @@ call activate vopt
 
 echo "Common Anaconda Packages:" && ^
 conda install --yes --quiet -c anaconda ^
-anaconda alembic beautifulsoup4 constantly coverage cvxcanon cvxopt django ecos flask ^
-gevent greenlet hyperlink incremental ipyparallel krb5 ^
-line_profiler matplotlib markdown nose pymongo psycopg2 requests scikit-learn scrapy seaborn simplejson sphinx sphinx_rtd_theme ^
-toolz twisted werkzeug ^
+anaconda ^
+alembic ^
+beautifulsoup4 ^
+constantly ^
+coverage ^
+cvxcanon ^
+cvxopt ^
+django ^
+ecos ^
+flask ^
+gevent ^
+greenlet ^
+hyperlink ^
+incremental ^
+ipyparallel ^
+krb5 ^
+line_profiler ^
+matplotlib ^
+markdown ^
+nose ^
+pymongo ^
+psycopg2 ^
+requests ^
+scikit-learn ^
+scrapy ^
+seaborn ^
+simplejson ^
+sphinx ^
+sphinx_rtd_theme ^
+toolz ^
+twisted ^
+werkzeug ^
 && ^
 echo "Common Anaconda Packages in Conda-Forge:" && ^
 conda install --yes --quiet -c conda-forge ^
-aniso8601 awscli fabric3 fastparquet feather-format glpk jupyter_nbextensions_configurator ^
-multiprocess pyarrow ^
+aniso8601 ^
+awscli ^
+fabric3 ^
+fastparquet ^
+feather-format ^
+glpk ^
+jupyter_nbextensions_configurator ^
+multiprocess ^
+pyarrow ^
 && ^
 echo "Common pip Packages:" && ^
 pip install ^
-autopep8 awscli coreapi cvxpy django-crispy-forms django-filter django-guardian ^
-django-jinja djangorestframework ^
-eve flask-restplus flask-security flask_sqlalchemy json-rpc nbsphinx ^
-scrapyd SQLAlchemy-Continuum tushare ^
+autopep8 ^
+coreapi ^
+cvxpy ^
+django-crispy-forms ^
+django-filter ^
+django-guardian ^
+django-jinja ^
+djangorestframework ^
+eve ^
+flask-restplus ^
+flask-security ^
+flask_sqlalchemy ^
+json-rpc ^
+nbsphinx ^
+scrapyd ^
+SQLAlchemy-Continuum ^
+tushare ^
 && ^
 echo "Jupyter notebook setting:" && ^
 ipcluster nbextension enable --user && ^
 jupyter nbextensions_configurator enable --user && ^
-echo
 
 call deactivate
 cmd.exe /K

--- a/install_pkg.bat
+++ b/install_pkg.bat
@@ -42,6 +42,8 @@ sphinx_rtd_theme ^
 toolz ^
 twisted ^
 werkzeug ^
+lxml ^
+cython ^
 && ^
 echo "Common Anaconda Packages in Conda-Forge:" && ^
 conda install --yes --quiet -c conda-forge ^


### PR DESCRIPTION
pyarrow 패키지는 win32 지원을 하지 않습니다.
autopep8, awscli 두 번씩 설치돼서 하나만 남기고 삭제했습니다.
pip 패키지는 몇 개만 OS 독립인 게 확인되고 나머지는 pypi 상에서 확인을 하기가 여려운 것 같습니다.
그리고 장고 패키지들 같은 경우 인덱스 이름이랑 패키지 이름이 똑같지가 않아서 맞는지 확인을 못 하겠습니다.
내일 말씀해주시면 마저 확인하겠습니다.